### PR TITLE
Fix checkNotNullParameter exception

### DIFF
--- a/android/src/main/java/com/reactnativepaypal/PaypalModule.kt
+++ b/android/src/main/java/com/reactnativepaypal/PaypalModule.kt
@@ -31,7 +31,7 @@ class PaypalModule(reactContext: ReactApplicationContext): ReactContextBaseJavaM
     activity: Activity,
     requestCode: Int,
     resultCode: Int,
-    intent: Intent
+    intent: Intent?
   ) {
   }
 


### PR DESCRIPTION
The fact that the intent parameter isn't being declared nullable seems to be causing some crashes
```
Caused by java.lang.NullPointerException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkNotNullParameter, parameter intent
  at com.reactnativepaypal.PaypalModule.onActivityResult
  at com.facebook.react.bridge.ReactContext.onActivityResult (ReactContext.java:328)
  at com.facebook.react.ReactInstanceManager.onActivityResult (ReactInstanceManager.java:828)
  at com.facebook.react.ReactDelegate.onActivityResult (ReactDelegate.java:90)
  at com.facebook.react.ReactActivityDelegate.onActivityResult (ReactActivityDelegate.java:113)
  at expo.modules.ReactActivityDelegateWrapper.onActivityResult (ReactActivityDelegateWrapper.kt:145)
  at com.facebook.react.ReactActivity.onActivityResult (ReactActivity.java:70)
  at android.app.Activity.dispatchActivityResult (Activity.java:8550)
  at android.app.ActivityThread.deliverResults (ActivityThread.java:5534)
```

https://github.com/facebook/react-native/blob/main/ReactAndroid/src/main/java/com/facebook/react/bridge/ActivityEventListener.java#L21

https://play.google.com/console/u/1/developers/4871294524400796545/app/4975233593092062189/vitals/crashes/e04a3c7dd9be46bf6d8086a260763949/details?installedFrom=PLAY_STORE&days=30&clustering=NEW&versionCode=3057000
